### PR TITLE
Update vscode dev dependency and fix build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@types/mocha": "5.2.7",
 		"typescript": "3.5.3",
 		"mocha": "6.2.0",
-		"vscode": "1.1.36",
+		"vscode": "1.1.37",
 		"vscode-debugadapter-testsupport": "1.37.0",
 		"tslint": "5.18.0",
 		"vsce": "1.66.0"

--- a/src/quickjsDebug.ts
+++ b/src/quickjsDebug.ts
@@ -507,7 +507,7 @@ export class QuickJSDebugSession extends SourcemapSession {
 
 	protected async threadsRequest(response: DebugProtocol.ThreadsResponse): Promise<void> {
 		if (this._threads.size === 0) {
-			await new Promise((resolve, reject) => {
+			await new Promise<void>((resolve, reject) => {
 				this.once('quickjs-thread', () => {
 					resolve();
 				});

--- a/src/sourcemapSession.ts
+++ b/src/sourcemapSession.ts
@@ -11,8 +11,8 @@ export abstract class SourcemapSession extends LoggingDebugSession {
 	// keep track of the sourcemaps and the location of the file.map used to load it
 	private _sourceMaps = new Map<BasicSourceMapConsumer, string>();
 
-	abstract async logTrace(message: string);
-	abstract async getArguments(): Promise<SourcemapArguments>;
+	abstract logTrace(message: string);
+	abstract getArguments(): Promise<SourcemapArguments>;
 
 	async loadSourceMaps() {
 		const commonArgs = await this.getArguments();
@@ -111,7 +111,6 @@ export abstract class SourcemapSession extends LoggingDebugSession {
 			this.logTrace(`translateFileLocationToRemote: ${JSON.stringify(sourceLocation)} to: ${JSON.stringify(actualSourceLocation)}`);
 			// convert the local absolute path into a sourcemap relative path.
 			actualSourceLocation.source = path.relative(path.dirname(sourcemap), sourceLocation.source);
-			delete actualSourceLocation.column;
 			// let unmappedPosition: NullablePosition = sm.generatedPositionFor(actualSourceLocation);
 			let unmappedPositions = sm.allGeneratedPositionsFor(actualSourceLocation);
 			if (!unmappedPositions || !unmappedPositions.length)


### PR DESCRIPTION
I was running into this problem: https://github.com/microsoft/vscode/issues/120064, so I had to update the `vscode` dependency.
Then I started getting some errors when running `npm install` and I fixed those as well.

After the changes I can do `RUN AND DEBUG > Extension + Server` from vscode and run QuickJS with the debugger successfully.